### PR TITLE
Minor bug fix

### DIFF
--- a/src/DecoderWorker.js
+++ b/src/DecoderWorker.js
@@ -707,6 +707,7 @@ function BinaryString(img,type){
 		corrections = 0
 		if(type == 0) len/=2;
 		binaryString=[];
+		EanCounter = 0;
 		bars=0;
 		binTemp=[]
 		trigger=false;


### PR DESCRIPTION
I found the EanCounter wasn't reset after each SlicedArray was read. Without a reset it is possible the switch will skip 5 bars for the center before all the bars in the leftSide have been read. Also added a few missing semicolons.
