### PR TITLE
Fix module exports and add ImageErrorCallback

### DIFF
--- a/src/BarcodeReader.js
+++ b/src/BarcodeReader.js
@@ -342,4 +342,12 @@ var BarcodeReader = {
   }
 };
 
-module.exports = BarcodeReader;
+
+if (typeof exports !== 'undefined') {
+  if (typeof module !== 'undefined' && module.exports) {
+      exports = module.exports = BarcodeReader;
+  }
+  exports.BarcodeReader = BarcodeReader;
+} else {
+  root.BarcodeReader = BarcodeReader;
+}

--- a/src/BarcodeReader.js
+++ b/src/BarcodeReader.js
@@ -43,6 +43,7 @@ var BarcodeReader = {
   ImageCallback: null, // Callback for the decoding of an image.
   StreamCallback: null, // Callback for the decoding of a video.
   LocalizationCallback: null, // Callback for localization.
+  ImageErrorCallback: null, // Callback for error on image loading.
   Stream: null, // The actual video.
   DecodeStreamActive: false, // Will be set to false when StopStreamDecode() is called.
   Decoded: [], // Used to enfore the ForceUnique property.
@@ -78,6 +79,11 @@ var BarcodeReader = {
   SetLocalizationCallback: function(callBack) {
     BarcodeReader.LocalizationCallback = callBack;
     BarcodeReader.Config.LocalizationFeedback = true;
+  },
+
+  // Sets the callback function when loading a wrong image.
+  SetImageErrorCallback: function(callBack) {
+    BarcodeReader.ImageErrorCallback = callBack;
   },
 
   // Set to true if LocalizationCallback is set and you would like to
@@ -191,7 +197,8 @@ var BarcodeReader = {
 
   // The image decoding function, image is a data source for an image or an image element.
   DecodeImage: function(image) {
-		var img = new Image();
+	var img = new Image();
+	img.onerror = BarcodeReader.ImageErrorCallback;
 
     if (image instanceof Image || image instanceof HTMLImageElement) {
       image.exifdata = false;

--- a/src/DecoderWorker.js
+++ b/src/DecoderWorker.js
@@ -2958,3 +2958,12 @@ var decoderWorkerBlob = function decoderWorkerBlob(){
 
 var decoderWorkerBlobString = decoderWorkerBlob.toString();
 decoderWorkerBlobString = decoderWorkerBlobString.substring(decoderWorkerBlobString.indexOf("{")+1, decoderWorkerBlobString.lastIndexOf("}"));
+
+if (typeof exports !== 'undefined') {
+  if (typeof module !== 'undefined' && module.exports) {
+      exports = module.exports = decoderWorkerBlobString;
+  }
+  exports.decoderWorkerBlobString = decoderWorkerBlobString;
+} else {
+  root.decoderWorkerBlobString = decoderWorkerBlobString;
+}


### PR DESCRIPTION
Fixed exporting modules for `DecoderWorker` and `BarcodeReader`, it wasn't working properly with webpack.
Also add an `ImageErrorCallback` called when a wrong image is loaded in `BarcodeReader.DecodeImage()`.
